### PR TITLE
bug fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module selfextract
+module github.com/synthesio/selfextract
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -93,9 +93,13 @@ const maxBoundaryOffset = 100e6 // 100 MB
 
 func readSelf() ([]byte, io.ReadCloser, []byte) {
 	t := time.Now()
-	self, err := os.Open(os.Args[0])
+	exePath, err := os.Executable()
 	if err != nil {
-		die("opening itself:", err)
+		panic(err)
+	}
+	self, err := os.Open(exePath)
+	if err != nil {
+		die("opening itself:", exePath, err)
 	}
 	debug("opened itself in", time.Since(t))
 


### PR DESCRIPTION
1. to support go install selfextract, add github.com full path to **go.mod…**
2. bug fix: when move selfextract to system PATH os.Args[0] not equals to full binary path